### PR TITLE
Updating reference to latest React version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "css-loader": "^0.15.1",
     "file-loader": "^0.8.4",
     "node-libs-browser": "^0.5.2",
-    "react": "0.14.0",
+    "react": "^0.14.2",
     "react-dom": "^0.14.0",
     "react-redux": "4.0.0",
     "redux": "v3.0.2",


### PR DESCRIPTION
Fixes dependency conflict in issue #64.

```
npm ERR! peerinvalid The package react@0.14.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-dom@0.14.2 wants react@^0.14.2
npm ERR! peerinvalid Peer react-redux@4.0.0 wants react@^0.14.0
```

Needed to specify React 0.14.2 or greater to satisfy react-dom requirements.

Thanks @happypoulp 
