### PR TITLE
Fix typo

### DIFF
--- a/10_middleware.js
+++ b/10_middleware.js
@@ -44,7 +44,7 @@
 
 // The middleware we have to build for our async action creator is called a thunk middleware and
 // its code is provided here: https://github.com/gaearon/redux-thunk.
-// Here is what it looks like (translated to es5 for readability):
+// Here is what it looks like (with function body translated to es5 for readability):
 
 var thunkMiddleware = function ({ dispatch, getState }) {
     // console.log('Enter thunkMiddleware');


### PR DESCRIPTION
ES5 is referenced when the actual code provided is using an ES6 feature.

And thanks for the great tutorial! Really helped me to understand some of the more nuances related to Redux (especially the middleware stuff!)
