### PR TITLE
Fixed all redirected URLs to updated 'rackt' URLS

### DIFF
--- a/01_simple-action-creator.js
+++ b/01_simple-action-creator.js
@@ -41,6 +41,6 @@ console.log(actionCreator())
 // ActionCreator -> Action
 
 // Read more about actions and action creators here:
-// http://gaearon.github.io/redux/docs/recipes/ReducingBoilerplate.html
+// http://rackt.org/redux/docs/recipes/ReducingBoilerplate.html
 
 // Go to next tutorial: 02_simple-subscriber.js

--- a/03_about-state-and-meet-redux.js
+++ b/03_about-state-and-meet-redux.js
@@ -10,7 +10,7 @@
 
 // Here comes Redux.
 
-// Redux (https://github.com/gaearon/redux) is a "predictable state container for JavaScript apps"
+// Redux (https://github.com/rackt/redux) is a "predictable state container for JavaScript apps"
 
 // Let's review the above questions and reply to them with
 // Redux vocabulary (flux vocabulary too for some of them):

--- a/10_middleware.js
+++ b/10_middleware.js
@@ -65,7 +65,7 @@ var thunkMiddleware = function ({ dispatch, getState }) {
 // "applyMiddleware" takes all your middlewares as parameters and returns a function to be called
 // with Redux createStore. When this last function is invoked, it will produce "a higher-order
 // store that applies middleware to a store's dispatch".
-// (from https://github.com/gaearon/redux/blob/v1.0.0-rc/src/utils/applyMiddleware.js)
+// (from https://github.com/rackt/redux/blob/v1.0.0-rc/src/utils/applyMiddleware.js)
 
 // Here is how you would integrate a middleware to your Redux store:
 
@@ -149,7 +149,7 @@ function discardMiddleware ({ dispatch, getState }) {
 //     const finalCreateStore = applyMiddleware(discardMiddleware, thunkMiddleware)(createStore)
 // should make your actions never reach your thunkMiddleware and even less your reducers.
 
-// See http://gaearon.github.io/redux/docs/introduction/Ecosystem.html, section Middlewares, to
+// See http://rackt.org/redux/docs/introduction/Ecosystem.html, section Middlewares, to
 // see other middleware examples.
 
 // Let's sum up what we've learned so far:

--- a/11_state-subscriber.js
+++ b/11_state-subscriber.js
@@ -80,7 +80,7 @@ store_0.dispatch(addItemActionCreator({ id: 1234, description: 'anything' }))
 // "Predictable state container for JavaScript apps" and you can use it in many ways, a React
 // application just being one of them.
 
-// In that perspective we would be a bit lost if it wasn't for react-redux (https://github.com/gaearon/react-redux).
+// In that perspective we would be a bit lost if it wasn't for react-redux (https://github.com/rackt/react-redux).
 // Previously integrated inside Redux (before 1.0.0), this repository holds all the bindings we need to simplify
 // our life when using Redux inside React.
 

--- a/12_src/src/application.jsx
+++ b/12_src/src/application.jsx
@@ -1,6 +1,6 @@
 // Tutorial 12 - Provider-and-connect.js
 
-// Now is the time to meet the first binding that redux-react (https://github.com/gaearon/react-redux)
+// Now is the time to meet the first binding that redux-react (https://github.com/rackt/react-redux)
 // brings to us: the Provider component.
 
 // Provider is a React Component designed to be used as a wrapper of your application's root component. Its

--- a/13_final-words.js
+++ b/13_final-words.js
@@ -2,14 +2,14 @@
 
 // There is actually more to Redux and react-redux than what we showed you with this tutorial. For example,
 // concerning Redux, you may be interested in bindActionCreators (to produce a hash of action creators
-// already bound to dispatch - http://gaearon.github.io/redux/docs/api/bindActionCreators.html).
+// already bound to dispatch - http://rackt.org/redux/docs/api/bindActionCreators.html).
 
-// We hope we've given you the keys to better understand Flux and to see more clearly 
+// We hope we've given you the keys to better understand Flux and to see more clearly
 // how Flux implementations differ from one another--especially how Redux stands out ;).
 
 // Where to go from here?
 
 // The official Redux documentation is really awesome and exhaustive so you should not hesitate to
-// refer to it from now on: http://gaearon.github.io/redux/
+// refer to it from now on: http://rackt.org/redux/index.html
 
 // Have fun with React and Redux!

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 redux-tutorial
 =========================
 
-This repository contains a step by step tutorial to get a grasp about flux and most particularly about [Redux](https://github.com/gaearon/redux).
+This repository contains a step by step tutorial to get a grasp about flux and most particularly about [Redux](https://github.com/rackt/redux).
 
 The official and very exhaustive Redux documentation is available [here](http://redux.js.org/) and should be your number One source of truth regarding Redux. The present tutorial only will offer you an introduction to flux concepts through Redux use but for further or more detailed info, please refer to the Redux documentation.
 


### PR DESCRIPTION
- Previous URLs were pointing to old 'gaeron' repos and website
- Old URLs would redirect to 'rackt' repos and website
- Updated URLs to point to their new locations
