### PR TITLE
fix minor typos, and update links

### DIFF
--- a/01_simple-action-creator.js
+++ b/01_simple-action-creator.js
@@ -36,7 +36,7 @@ console.log(actionCreator())
 // To dispatch an action we need... a dispatch function ("Captain obvious").
 // And to let anyone interested know that an action happened, we need a mechanism to register
 // "handlers". Such "handlers" to actions in traditional flux application are called stores and
-// we'll see in the next section how they are called in redux.
+// we'll see in the next section how they are called in Redux.
 
 // So far here is the flow of our application:
 // ActionCreator -> Action

--- a/03_simple-reducer.js
+++ b/03_simple-reducer.js
@@ -18,7 +18,7 @@ import { createStore } from 'redux'
 var store_0 = createStore(() => {})
 
 // ... so that Redux can call this function on your application state each time an action occurs.
-// Giving reducer(s) to createStore is exactly how redux registers the action "handlers" (read reducers) we
+// Giving reducer(s) to createStore is exactly how Redux registers the action "handlers" (read reducers) we
 // were talking about in section 01_simple-action-creator.js.
 
 // Let's put some log in our reducer

--- a/04_get-state.js
+++ b/04_get-state.js
@@ -81,7 +81,7 @@ var store_3 = createStore(reducer_3)
 // Output: reducer_3 was called with state {} and action { type: '@@redux/INIT' }
 
 console.log('store_3 state after initialization:', store_3.getState())
-// Output: redux state after initialization: {}
+// Output: store_3 state after initialization: {}
 
 // Nothing new in our state so far since we did not dispatch any action yet. But there are few
 // important things to pay attention to in the last example:

--- a/07_dispatch-async-action-1.js
+++ b/07_dispatch-async-action-1.js
@@ -14,7 +14,7 @@
 // Of course this message is part of our application state so we have to save it
 // in Redux store. But what we want is to have our store save the message
 // only 2 seconds after the action creator is called (because if we were to update our state
-// immediately, any subscriber to state's modifications - like our view -  would be notified right away
+// immediately, any subscriber to state's modifications - like our view - would be notified right away
 // and would then react to this update 2 seconds too soon).
 
 // If we were to call an action creator like we did until now...

--- a/09_middleware.js
+++ b/09_middleware.js
@@ -34,9 +34,9 @@
 */
 
 // As you can see above, a middleware is made of 3 nested functions (that will get called sequentially):
-// 1) The first level provide the dispatch function and a getState function (if your
+// 1) The first level provides the dispatch function and a getState function (if your
 //     middleware or your action creator needs to read data from state) to the 2 other levels
-// 2) The second level provide the next function that will allow you to explicitly hand over
+// 2) The second level provides the next function that will allow you to explicitly hand over
 //     your transformed input to the next middleware or to Redux (so that Redux can finally call all reducers).
 // 3) the third level provides the action received from the previous middleware or from your dispatch
 //     and can either trigger the next middleware (to let the action continue to flow) or process
@@ -44,9 +44,9 @@
 
 // Those of you who are trained to functional programming may have recognized above an opportunity
 // to apply a functional pattern: currying (if you aren't, don't worry, skipping the next 10 lines
-// won't affect your redux understanding). Using currying, you could simplify the above function like that:
+// won't affect your Redux understanding). Using currying, you could simplify the above function like that:
 /*
-    // "curry" may come any functional programming library (lodash, ramda, etc.)
+    // "curry" may come from any functional programming library (lodash, ramda, etc.)
     var thunkMiddleware = curry(
         ({dispatch, getState}, next, action) => (
             // your middleware-specific code goes here
@@ -79,7 +79,7 @@ var thunkMiddleware = function ({ dispatch, getState }) {
 // store that applies middleware to a store's dispatch".
 // (from https://github.com/rackt/redux/blob/v1.0.0-rc/src/utils/applyMiddleware.js)
 
-// Here is how you would integrate a middleware to your Redux store:
+// Here is how you would integrate a middleware into your Redux store:
 
 import { createStore, combineReducers, applyMiddleware } from 'redux'
 
@@ -144,7 +144,7 @@ function logMiddleware ({ dispatch, getState }) {
     }
 }
 
-// Same below for a middleware to discard all actions that goes through (not very useful as is
+// Same below for a middleware to discard all actions that are dispatched (not very useful as is
 // but with a bit of more logic it could selectively discard a few actions while passing others
 // to next middleware or Redux):
 function discardMiddleware ({ dispatch, getState }) {
@@ -161,7 +161,7 @@ function discardMiddleware ({ dispatch, getState }) {
 //     const finalCreateStore = applyMiddleware(discardMiddleware, thunkMiddleware)(createStore)
 // should make your actions never reach your thunkMiddleware and even less your reducers.
 
-// See http://rackt.org/redux/docs/introduction/Ecosystem.html, section Middlewares, to
+// See http://rackt.org/redux/docs/introduction/Ecosystem.html, section Middleware, to
 // see other middleware examples.
 
 // Let's sum up what we've learned so far:
@@ -170,7 +170,7 @@ function discardMiddleware ({ dispatch, getState }) {
 // 3) We know how to handle custom actions like asynchronous actions thanks to middlewares
 
 // The only missing piece to close the loop of Flux application is to be notified about
-// state updates to be able to react to them (by re-rendering our components for example).
+// state updates in order to react to them (by re-rendering our components for example).
 
 // So how do we subscribe to our Redux store updates?
 

--- a/09_middleware.js
+++ b/09_middleware.js
@@ -161,7 +161,7 @@ function discardMiddleware ({ dispatch, getState }) {
 //     const finalCreateStore = applyMiddleware(discardMiddleware, thunkMiddleware)(createStore)
 // should make your actions never reach your thunkMiddleware and even less your reducers.
 
-// See http://rackt.org/redux/docs/introduction/Ecosystem.html, section Middleware, to
+// See http://redux.js.org/docs/introduction/Ecosystem.html#middleware, section Middleware, to
 // see other middleware examples.
 
 // Let's sum up what we've learned so far:

--- a/10_state-subscriber.js
+++ b/10_state-subscriber.js
@@ -9,7 +9,7 @@
 
 // Without it, we cannot update our views when the store changes.
 
-// Fortunately, there is a very simple way to "watch" over our Redux's store updates:
+// Fortunately, there is a very simple way to "watch" over our Redux store's updates:
 
 /*
     store.subscribe(function() {
@@ -88,7 +88,7 @@ store_0.dispatch(addItemActionCreator({ id: 1234, description: 'anything' }))
 // the same time also seems to not provide enough features?
 
 // Its simplicity is actually its power! Redux, with its current minimalist API (including "subscribe") is
-//  highly extensible and this allows developers to build some crazy products like the Redux DevTools
+// highly extensible and this allows developers to build some crazy products like the Redux DevTools
 // (https://github.com/gaearon/redux-devtools).
 
 // But in the end we still need a "better" API to subscribe to our store changes. That's exactly what react-redux
@@ -97,7 +97,7 @@ store_0.dispatch(addItemActionCreator({ id: 1234, description: 'anything' }))
 // use bindings such as "provide" or "connect" and those will hide from you the "subscribe" method.
 
 // So yeah, the "subscribe" method will still be used but it will be done through a higher order API that
-// handles access to redux state for you.
+// handles access to Redux state for you.
 
 // We'll now cover those bindings and show how simple it is to wire your components to Redux's state.
 

--- a/11_Provider-and-connect.js
+++ b/11_Provider-and-connect.js
@@ -31,7 +31,7 @@ import server from './11_src/src/server'
 // if port equals X, we'll use X for server's port and X+1 for webpack-dev-server's port
 const port = 5050
 
-// Start our webpack dev server...
+// Start our Webpack dev server...
 webpackDevServer.listen(port)
 // ... and our main app server.
 server.listen(port)

--- a/11_src/src/application.jsx
+++ b/11_src/src/application.jsx
@@ -1,13 +1,11 @@
 // Tutorial 12 - Provider-and-connect.js
 
-// Now is the time to meet the first binding that redux-react (https://github.com/rackt/react-redux)
+// Now is the time to meet the first binding that redux-react (https://github.com/reactjs/react-redux)
 // brings to us: the Provider component.
 
 // Provider is a React Component designed to be used as a wrapper of your application's root component. Its
-// purpose is to provide your redux instance to all of your application's components. How it does that does not
-// really matter to us but just to let you know, it's using React's context feature (it's undocumented so you
-// don't have to know about it, but if you're curious:
-// https://www.tildedave.com/2014/11/15/introduction-to-contexts-in-react-js.html).
+// purpose is to provide your Redux instance to all of your application's components. Documentation is here:
+// https://github.com/reactjs/react-redux/blob/3.x/docs/api.md#provider-store
 
 import React from 'react'
 import Home from './home'

--- a/11_src/src/create-store.js
+++ b/11_src/src/create-store.js
@@ -19,7 +19,7 @@ import promiseMiddleware from './promise-middleware'
 // ./reducers.js to see what our reducer actually do (no magic there).
 import * as reducers from './reducers'
 
-// The data parameter that we see here is used to initialize our redux store with data. We didn't
+// The data parameter that we see here is used to initialize our Redux store with data. We didn't
 // talk about this yet for simplicity but thanks to it your reducers can be initialized
 // with real data if you already have some. For example in an isomorphic/universal app where you
 // fetch data server-side, serialize and pass it to the client, your Redux store can be

--- a/11_src/src/index.jsx
+++ b/11_src/src/index.jsx
@@ -10,7 +10,7 @@ import createStore from './create-store'
 // Application is the root component of our application and the one that holds Redux's Provider...
 import Application from './application'
 
-// Just as we did so many times in previous examples, we need to create our redux instance. This time
+// Just as we did so many times in previous examples, we need to create our Redux instance. This time
 // all code for that task was moved to a specific module that returns a single function to trigger the
 // instantiation.
 const store = createStore()

--- a/11_src/src/server.js
+++ b/11_src/src/server.js
@@ -9,12 +9,12 @@
 // 2) the connect function
 
 // But before we get to that, let's see the basic setup of this application and how it
-// will be served to browser...
+// will be served to a browser...
 
 // We won't use Express (http://expressjs.com/) in this app since we don't really need
 // it to serve a simple html page.
 
-// "http" module will be used to create the http server
+// "http" module will be used to create the HTTP server
 import http from 'http'
 import React from 'react'
 
@@ -30,7 +30,7 @@ var server = http.createServer(function(req, res) {
 
   // And of course, here is our Application HTML that we're sending back to the browser.
   // Nothing special here except the URI of our application JS bundle that points to our
-  // webpack dev server (located at http://localhost:5051)
+  // Webpack dev server (located at http://localhost:5051)
   res.write(
     `<!DOCTYPE html>
     <html>
@@ -49,6 +49,6 @@ var server = http.createServer(function(req, res) {
 
 export default server
 
-// Go to ./index.jsx, where our app is initialized. For those of you who are not familiar with webpack,
+// Go to ./index.jsx, where our app is initialized. For those of you who are not familiar with Webpack,
 // index.jsx is defined as the entry point (the first file) of our JS bundle (in 12_src/webpack.config.js)
 // and is automatically executed when the JS bundle is loaded in our browser.

--- a/12_final-words.js
+++ b/12_final-words.js
@@ -2,7 +2,7 @@
 
 // There is actually more to Redux and react-redux than what we showed you with this tutorial. For example,
 // concerning Redux, you may be interested in bindActionCreators (to produce a hash of action creators
-// already bound to dispatch - http://rackt.org/redux/docs/api/bindActionCreators.html).
+// already bound to dispatch - http://redux.js.org/docs/api/bindActionCreators.html).
 
 // We hope we've given you the keys to better understand Flux and to see more clearly
 // how Flux implementations differ from one another - especially how Redux stands out ;).
@@ -10,6 +10,6 @@
 // Where to go from here?
 
 // The official Redux documentation is really awesome and exhaustive so you should not hesitate to
-// refer to it from now on: http://rackt.org/redux/index.html
+// refer to it from now on: http://redux.js.org/
 
 // Have fun with React and Redux!

--- a/12_final-words.js
+++ b/12_final-words.js
@@ -5,7 +5,7 @@
 // already bound to dispatch - http://rackt.org/redux/docs/api/bindActionCreators.html).
 
 // We hope we've given you the keys to better understand Flux and to see more clearly
-// how Flux implementations differ from one another--especially how Redux stands out ;).
+// how Flux implementations differ from one another - especially how Redux stands out ;).
 
 // Where to go from here?
 


### PR DESCRIPTION
I noticed some minor typos and out-of-date links while reading through this (helpful!) tutorial.
