### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ The official and very exhaustive Redux documentation is available [here](http://
 ### Prerequisites
 It is required for you to know a bit of ES6 and ES7 (Object Spread) to correctly understand some of the examples given in this repo. Also be aware that this tutorial targets redux 3.0.2 and react-redux 4.0.0.
 
+### Nitrous Quickstart
+
+You can quickly create a free development environment for this redux-tutorial project in the cloud on www.nitrous.io:
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+Simply run `npm run example 01_simple-action-creator.js` from the terminal inside of `~/code/redux-tutorial/`
+
 ### Clone the repository
 `git clone https://github.com/happypoulp/redux-tutorial.git`
 

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,12 @@
+# Setup
+
+Welcome to your Redux Tutorial project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), enter the following commands in the terminal window:
+
+1. `cd ~/code/redux-tutorial`
+2. `npm run example 01_simple-action-creator.js`
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,9 @@
+{
+  "template": "nodejs",
+  "ports": [],
+  "name": "redux-tutorial",
+  "description": "This repository contains a step by step tutorial to help grasp flux and more specifically Redux.",
+  "scripts": {
+    "post-create": "cd ~/code/redux-tutorial && echo 'running npm install...' && npm install --no-progress && echo 'done npm install'"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.
